### PR TITLE
Import Service

### DIFF
--- a/Models/KuduCommandResult.cs
+++ b/Models/KuduCommandResult.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WordPressMigrationTool
+{
+    public class KuduCommandApiResult {
+        public Status status { get; set; }
+        public string output { get; set; }
+        public string error { get; set; }
+        public int exitCode { get; set; }
+
+        public KuduCommandApiResult(Status status, string output = null, string error = null, int exitCode = -1) {
+            this.status = status;
+            this.output = output;
+            this.error = error;
+            this.exitCode = exitCode;
+        }
+    }
+
+    public class KuduCommandApiResponse
+    {
+        public string Output { get; set; }
+        public string Error { get; set; }
+        public int ExitCode { get; set; }
+    }
+}

--- a/Services/ImportService.cs
+++ b/Services/ImportService.cs
@@ -96,7 +96,7 @@ namespace WordPressMigrationTool
                 Directory.Delete(splitZipFilesDirectory, true);
             }
 
-            string zippedSplitZipFIlesDirectory = Constants.WPCONTENT_SPLIT_ZIP_NESTED_DIR;
+            string zippedSplitZipFIlesDirectory = Environment.ExpandEnvironmentVariables(Constants.WPCONTENT_SPLIT_ZIP_NESTED_DIR);
             if (Directory.Exists(zippedSplitZipFIlesDirectory))
             {
                 Directory.Delete(zippedSplitZipFIlesDirectory, true);

--- a/Services/LinuxAppDataImportService.cs
+++ b/Services/LinuxAppDataImportService.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Net;
+using System.Threading;
+using System.IO;
+using WordPressMigrationTool.Utilities;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WordPressMigrationTool
+{
+    public class LinuxAppDataImportService
+    {
+
+        private string _ftpUserName;
+        private string _ftpPassword;
+        private string _appServiceName;
+        private string[] _splitZipFilesArr;
+        private int _retriesCount = 0;
+        private readonly SemaphoreSlim _binaryLock = new SemaphoreSlim(0);
+
+
+        public LinuxAppDataImportService(string appServiceName, string ftpUserName, string ftpPassword)
+        {
+            if (string.IsNullOrWhiteSpace(appServiceName))
+            {
+                throw new ArgumentException("Invalid AppService name found! " +
+                    "appServiceName=", appServiceName);
+            }
+
+            if (string.IsNullOrWhiteSpace(ftpUserName))
+            {
+                throw new ArgumentException("Invalid FTP username found! " +
+                    "ftpUsername=" + ftpUserName);
+            }
+
+            if (string.IsNullOrWhiteSpace(appServiceName))
+            {
+                throw new ArgumentException("Invalid FTP password found! " +
+                    "ftpPassword=" + ftpPassword);
+            }
+
+            this._appServiceName = appServiceName;
+            this._ftpUserName = ftpUserName;
+            this._ftpPassword = ftpPassword;
+        }
+
+        public Result importData()
+        {
+            string uploadWpContentKuduUrl = HelperUtils.getKuduUrlForZipUpload(this._appServiceName, "site/wwwroot/wp-content");
+            string directoryPath = Environment.ExpandEnvironmentVariables(Constants.DATA_EXPORT_PATH);
+            string appContentFilePath = Environment.ExpandEnvironmentVariables(Constants.WIN_APPSERVICE_DATA_EXPORT_PATH);
+            string appContentFileName = Constants.WIN_WPCONTENT_ZIP_FILENAME;
+
+            Console.WriteLine("Exporting App Service data to " + appContentFilePath);
+            Stopwatch timer = Stopwatch.StartNew();
+
+            if (!HelperUtils.ClearAppServiceDirectory(Constants.LIN_APP_SVC_WPCONTENT_DIR, this._ftpUserName, this._ftpPassword, this._appServiceName))
+            {
+                return new Result(Status.Failed, "Could not clear wp-content directory in App Service");
+            }
+
+            Result result = splitWpContentZip();
+            if (result.status == Status.Failed || result.status == Status.Cancelled)
+            {
+                return result;
+            }
+
+            this._splitZipFilesArr = Directory.GetFiles(Environment.ExpandEnvironmentVariables(Constants.WPCONTENT_SPLIT_ZIP_FILES_DIR));
+            if (this._splitZipFilesArr.Length == 0)
+            {
+                return new Result(Status.Failed, "App Service data not found at " + appContentFilePath);
+            }
+
+            for (int splitInd = 0; splitInd < this._splitZipFilesArr.Length; splitInd++)
+            {
+                string splitZipFileName = Path.GetFileName(this._splitZipFilesArr[splitInd]);
+                if (!this._uploadSplitZipFileToAppService(splitZipFileName))
+                {
+                    return new Result(Status.Failed, "Could not upload wp-content to app service");
+                }
+            }
+
+            // merges split zip files and extracts to wp-content directory in app service
+            if (! this._processSplitZipFiles())
+            {
+                return new Result(Status.Failed, "Could not upload wp-content to app service");
+            }
+
+            //Console.WriteLine("Sucessfully uploaded App Service data... Time Taken={0} seconds", (timer.ElapsedMilliseconds / 1000));
+            return new Result(Status.Completed, "Successfully uploaded App Service data.");
+        }
+
+        private bool _uploadSplitZipFileToAppService(string splitZipFileName)
+        {
+            string zippedSplitZipFilesDir = Environment.ExpandEnvironmentVariables(Constants.WPCONTENT_SPLIT_ZIP_NESTED_DIR);
+            string zippedFileToUpload = zippedSplitZipFilesDir + splitZipFileName.Replace(".", "") + ".zip";
+            string splitZipFilePath = Environment.ExpandEnvironmentVariables(Constants.WPCONTENT_SPLIT_ZIP_FILES_DIR + splitZipFileName);
+            string uploadWpContentKuduUrl = HelperUtils.getKuduUrlForZipUpload(this._appServiceName, Constants.WPCONTENT_TEMP_DIR_KUDU_API);
+
+            if (Directory.Exists(zippedSplitZipFilesDir))
+            {
+                Directory.Delete(zippedSplitZipFilesDir, true);
+            }
+            Directory.CreateDirectory(zippedSplitZipFilesDir);
+
+            var zipFile = new Ionic.Zip.ZipFile(Encoding.UTF8);
+            zipFile.AddFile(splitZipFilePath, "");
+            zipFile.Save(zippedFileToUpload);
+
+            if (!HelperUtils.LinAppServiceUploadZip(zippedFileToUpload, uploadWpContentKuduUrl, this._ftpUserName, this._ftpPassword))
+                return false;
+
+            return true;
+        }
+
+        private bool _processSplitZipFiles()
+        {
+            string mergeSplitZipCommand = Constants.WPCONTENT_MERGE_SPLLIT_FILES_COMAMND;
+            KuduCommandApiResult mergeSplitZipResult = HelperUtils.executeKuduCommandApi(mergeSplitZipCommand, this._ftpUserName, this._ftpPassword, this._appServiceName);
+            if (mergeSplitZipResult.status != Status.Completed)
+            {
+                return false;
+            }
+
+            string unzipMergedSplitFileCommand = Constants.UNZIP_MERGED_WPCONTENT_COMMAND;
+            KuduCommandApiResult unzipMergedSplitFileResult = HelperUtils.executeKuduCommandApi(unzipMergedSplitFileCommand, this._ftpUserName, this._ftpPassword, this._appServiceName);
+            if (unzipMergedSplitFileResult.status != Status.Completed)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private Result splitWpContentZip()
+        {
+            string appContentFilePath = Environment.ExpandEnvironmentVariables(Constants.WIN_APPSERVICE_DATA_EXPORT_PATH);
+            string splitZipFilesDirectory = Environment.ExpandEnvironmentVariables(Constants.WPCONTENT_SPLIT_ZIP_FILES_DIR);
+            string splitZipFilePath = Environment.ExpandEnvironmentVariables(Constants.WPCONTENT_SPLIT_ZIP_FILE_PATH);
+
+            //needs testing
+            if (Directory.Exists(splitZipFilesDirectory))
+            {
+                Directory.Delete(splitZipFilesDirectory, true);
+            }
+
+            Directory.CreateDirectory(splitZipFilesDirectory);
+
+            try
+            {
+                using (var zipFile = Ionic.Zip.ZipFile.Read(appContentFilePath))
+                {
+                    zipFile.MaxOutputSegmentSize = Constants.KUDU_ZIP_API_MAX_UPLOAD_LIMIT;
+                    zipFile.Save(splitZipFilePath);
+                }
+                return new Result(Status.Completed, "Zip file split successful...");
+            }
+            catch
+            {
+                return new Result(Status.Failed, "Couldn't split zip file...");
+            }
+        }
+    }
+}

--- a/Services/LinuxMySQLDataImportService.cs
+++ b/Services/LinuxMySQLDataImportService.cs
@@ -1,0 +1,216 @@
+﻿using System;
+using System.IO;
+using WordPressMigrationTool.Utilities;
+using MySql.Data.MySqlClient;
+using System.IO.Compression;
+using System.Diagnostics;
+using System.Net.Http;
+using System.Text;
+using Newtonsoft.Json;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using Azure.ResourceManager.AppService;
+
+namespace WordPressMigrationTool
+{
+    public class LinuxMySQLDataImportService
+    {
+        WebSiteResource _destinationSiteResource;
+        private string _ftpUserName;
+        private string _ftpPassword;
+        private string _appServiceName;
+        private string _serverHostName;
+        private string _username;
+        private string _password;
+        private string _databaseName;
+        private int _retriesCount = 0;
+
+
+        public LinuxMySQLDataImportService(WebSiteResource destinationSiteResource, string serverHostName, string username,
+            string password, string databaseName, string appServiceName, 
+            string ftpUserName, string ftpPassword)
+        {
+            if(destinationSiteResource == null)
+            {
+                throw new ArgumentException("Invalid Destination website resource found! ");
+            }
+
+            if (string.IsNullOrWhiteSpace(serverHostName))
+            {
+                throw new ArgumentException("Invalid MySQL servername found! " +
+                    "serverHostName=", serverHostName);
+            }
+
+            if (string.IsNullOrWhiteSpace(username))
+            {
+                throw new ArgumentException("Invalid MySQL username found! " +
+                    "username=" + username);
+            }
+
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                throw new ArgumentException("Invalid MySQL password found! " +
+                    "password=" + password);
+            }
+
+            if (string.IsNullOrWhiteSpace(databaseName))
+            {
+                throw new ArgumentException("Invalid database name found! " +
+                    "databaseName=" + databaseName);
+            }
+
+            if (string.IsNullOrWhiteSpace(appServiceName))
+            {
+                throw new ArgumentException("Invalid AppService name found! " +
+                    "appServiceName=", appServiceName);
+            }
+
+            if (string.IsNullOrWhiteSpace(ftpUserName))
+            {
+                throw new ArgumentException("Invalid FTP username found! " +
+                    "ftpUsername=" + ftpUserName);
+            }
+
+            if (string.IsNullOrWhiteSpace(appServiceName))
+            {
+                throw new ArgumentException("Invalid FTP password found! " +
+                    "ftpPassword=" + ftpPassword);
+            }
+
+            this._destinationSiteResource = destinationSiteResource;
+            this._serverHostName = serverHostName;
+            this._username = username;
+            this._password = password;
+            this._databaseName = databaseName;
+            this._appServiceName = appServiceName;
+            this._ftpUserName = ftpUserName;
+            this._ftpPassword = ftpPassword;
+        }
+
+        public Result importData()
+        {
+            string directoryPath = Environment.ExpandEnvironmentVariables(Constants.DATA_EXPORT_PATH);
+            string outputSqlFilePath = Environment.ExpandEnvironmentVariables(Constants.WIN_MYSQL_DATA_EXPORT_SQLFILE_PATH);
+            string mySqlZipFilePath = Environment.ExpandEnvironmentVariables(Constants.WIN_MYSQL_DATA_EXPORT_COMPRESSED_SQLFILE_PATH);
+
+            Stopwatch timer = Stopwatch.StartNew();
+
+            if (!_setupMySqlDumpPlaceholderDirectory())
+            {
+                return new Result(Status.Failed, "Could not setup placeholder directory in destination app service for MySQL dump...");
+            }
+
+            Result mysqlDumpUploadResult = this._uploadMySqlDump();
+            if (mysqlDumpUploadResult.status != Status.Completed)
+            {
+                return mysqlDumpUploadResult;
+            }
+
+            if (!this._startDatabaseImportInAppContainer())
+            {
+                return new Result(Status.Failed, "Could not initiate MySQL Database import in Destination App Service...");
+            }
+
+
+            if (!this._waitForDBImportInAppService())
+            {
+                return new Result(Status.Failed, "Could not verify MySQL Database import completed in Destination App Service...");
+            }
+
+            if (!this._stopDatabaseImportInAppContainer())
+            {
+                return new Result(Status.Failed, "Could not remove App Settings that trigger MySQL Database import in Destination App Service...");
+            }
+
+            return new Result(Status.Completed, "MySQL Database import completed...");
+        }
+
+        private Result _uploadMySqlDump()
+        {
+            string uploadMySqlDumpKuduUrl = HelperUtils.getKuduUrlForZipUpload(this._appServiceName, Constants.LIN_MYSQL_DUMP_UPLOAD_PATH_FOR_KUDU_API);
+            string mySqlZipFilePath = Environment.ExpandEnvironmentVariables(Constants.WIN_MYSQL_DATA_EXPORT_COMPRESSED_SQLFILE_PATH);
+
+            if (!File.Exists(mySqlZipFilePath))
+            {
+                return new Result(Status.Failed, "MySQL dump not found at " + mySqlZipFilePath);
+            }
+
+            bool MySqlZipFileUploadResult = HelperUtils.LinAppServiceUploadZip(mySqlZipFilePath, uploadMySqlDumpKuduUrl, this._ftpUserName, this._ftpPassword);
+            if (!MySqlZipFileUploadResult)
+            {
+                return new Result(Status.Failed, "Couldn't Upload MySql dump file..");
+            }
+
+            //Console.WriteLine("Sucessfully uploaded MySQL dump to App Service... Time Taken={0} seconds", (timer.ElapsedMilliseconds / 1000));
+            return new Result(Status.Completed, "Successfully uploaded MySQL dump.");
+        }
+
+        // Creates MySQL Dump placeholder directory in the destination app service
+        private bool _setupMySqlDumpPlaceholderDirectory()
+        {
+            // Clear existing files in MySQL placeholder directory
+            if (!HelperUtils.ClearAppServiceDirectory(Constants.MYSQL_TEMP_DIR, this._ftpUserName, this._ftpPassword, this._appServiceName))
+                return false;
+
+            //Create MYSQL placeholder directory if not already exists 
+            KuduCommandApiResult createMySqlDirectoryResult = HelperUtils.executeKuduCommandApi(Constants.MYSQL_CREATE_TEMP_DIR_COMMAND, this._ftpUserName, this._ftpPassword, this._appServiceName);
+            if (createMySqlDirectoryResult.status != Status.Completed)
+            {
+                return false;
+            }
+            return true;
+              
+        }
+
+        public bool _startDatabaseImportInAppContainer()
+        {
+            Dictionary<string,string> appSettings = new Dictionary<string,string>();
+            appSettings.Add(Constants.START_MIGRATION_APP_SETTING, "True");
+            appSettings.Add(Constants.NEW_DATABASE_NAME_APP_SETTING, this._databaseName);
+            appSettings.Add(Constants.MYSQL_DUMP_FILE_PATH_APP_SETTING, String.Format("{0}{1}.sql", Constants.MYSQL_TEMP_DIR, this._databaseName));
+
+            try
+            {
+                return AzureManagementUtils.UpdateApplicationSettingForAppService(this._destinationSiteResource, appSettings);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public bool _stopDatabaseImportInAppContainer()
+        {
+            string[] appSettings = { Constants.START_MIGRATION_APP_SETTING, Constants.NEW_DATABASE_NAME_APP_SETTING, Constants.MYSQL_DUMP_FILE_PATH_APP_SETTING };
+
+            try
+            {
+                return AzureManagementUtils.removeApplicationSettingForAppService(this._destinationSiteResource, appSettings);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public bool _waitForDBImportInAppService()
+        {
+            string checkDbImportStatusNestedCommand = String.Format("grep '{0}' {1}", Constants.DB_IMPORT_STATUS_MESSAGE, Constants.LIN_APP_DB_STATUS_FILE_PATH);
+            
+            int maxRetryCount = 10000;
+            for (int i=0; i<maxRetryCount; i++)
+            {
+                KuduCommandApiResult checkDbImportStatusResult = HelperUtils.executeKuduCommandApi(checkDbImportStatusNestedCommand, this._ftpUserName, this._ftpPassword, this._appServiceName);
+                if (checkDbImportStatusResult.status == Status.Completed
+                    && checkDbImportStatusResult.exitCode == 0
+                    && checkDbImportStatusResult.output != null && checkDbImportStatusResult.output.Contains(Constants.DB_IMPORT_STATUS_MESSAGE))
+                {
+                    return true;
+                }
+                // Sleep for 10s
+                Thread.Sleep(10000);
+            }
+            return false;
+        }
+    }
+}

--- a/Services/LinuxMySQLDataImportService.cs
+++ b/Services/LinuxMySQLDataImportService.cs
@@ -198,17 +198,21 @@ namespace WordPressMigrationTool
 
         public bool _waitForDBImportInAppService()
         {
-            string checkDbImportStatusNestedCommand = String.Format("grep '{0}' {1}", Constants.DB_IMPORT_STATUS_MESSAGE, Constants.LIN_APP_DB_STATUS_FILE_PATH);
+            string checkDbImportStatusNestedCommand = String.Format("cat {0}", Constants.LIN_APP_DB_STATUS_FILE_PATH);
             
-            int maxRetryCount = 10000;
+            int maxRetryCount = 2000;
             for (int i=0; i<maxRetryCount; i++)
             {
                 KuduCommandApiResult checkDbImportStatusResult = HelperUtils.executeKuduCommandApi(checkDbImportStatusNestedCommand, this._ftpUserName, this._ftpPassword, this._appServiceName);
                 if (checkDbImportStatusResult.status == Status.Completed
                     && checkDbImportStatusResult.exitCode == 0
-                    && checkDbImportStatusResult.output != null && checkDbImportStatusResult.output.Contains(Constants.DB_IMPORT_STATUS_MESSAGE))
+                    && checkDbImportStatusResult.output != null)
                 {
-                    return true;
+                    if (checkDbImportStatusResult.output.Contains(Constants.DB_IMPORT_SUCCESS_MESSAGE))
+                        return true;
+                    
+                    if (checkDbImportStatusResult.output.Contains(Constants.DB_IMPORT_FAILURE_MESSAGE))
+                        return false;
                 }
                 // Sleep for 10s
                 Thread.Sleep(10000);

--- a/Services/MigrationService.cs
+++ b/Services/MigrationService.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using WordPressMigrationTool.Utilities;
+using System.Threading.Tasks;
 
 namespace WordPressMigrationTool
 {
     public class MigrationService
     {
 
-        public Result Migrate(SiteInfo sourceSite, SiteInfo destinationSite)
+         public Result migrate(SiteInfo sourceSite, SiteInfo destinationSite)
         {
             try
             {
@@ -19,7 +20,7 @@ namespace WordPressMigrationTool
                     return exporttRes;
                 }
 
-                Result importRes = importService.ImportDataToDestinationSite(destinationSite, sourceSite.databaseName);
+                Result importRes = importService.importDataToDestinationSite(destinationSite, sourceSite.databaseName);
                 if (importRes.status == Status.Failed || importRes.status == Status.Cancelled)
                 {
                     return importRes;

--- a/Services/MigrationService.cs
+++ b/Services/MigrationService.cs
@@ -7,7 +7,7 @@ namespace WordPressMigrationTool
     public class MigrationService
     {
 
-         public Result migrate(SiteInfo sourceSite, SiteInfo destinationSite)
+        public Result migrate(SiteInfo sourceSite, SiteInfo destinationSite)
         {
             try
             {
@@ -26,11 +26,46 @@ namespace WordPressMigrationTool
                     return importRes;
                 }
 
+                this.cleanLocalTempFiles();
+
+                if (!this.cleanDestinationAppTempFiles(destinationSite))
+                {
+                    return new Result(Status.Failed, "Could not clean intermediary files on Destination site...");
+                }
+
                 return new Result(Status.Completed, Constants.SUCCESS_MESSAGE);
             }
             catch (Exception ex) {
                 return new Result(Status.Failed, ex.Message);
             }
         }
+
+        private void cleanLocalTempFiles()
+        {
+            string splitZipFilesDirectory = Environment.ExpandEnvironmentVariables(Constants.WPCONTENT_SPLIT_ZIP_FILES_DIR);
+            if (Directory.Exists(splitZipFilesDirectory))
+            {
+                Directory.Delete(splitZipFilesDirectory, true);
+            }
+
+            string zippedSplitZipFIlesDirectory = Environment.ExpandEnvironmentVariables(Constants.WPCONTENT_SPLIT_ZIP_NESTED_DIR);
+            if (Directory.Exists(zippedSplitZipFIlesDirectory))
+            {
+                Directory.Delete(zippedSplitZipFIlesDirectory, true);
+            }
+
+            string localDataExportDirectory = Environment.ExpandEnvironmentVariables(Constants.DATA_EXPORT_PATH);
+            if(Directory.Exists(localDataExportDirectory))
+            {
+                Directory.Delete(localDataExportDirectory, true);
+            }            
+        }
+
+        private bool cleanDestinationAppTempFiles(SiteInfo destinationSite)
+        {
+            string linAppMigrateIntermerdiateDirectory = Constants.LIN_APP_SVC_MIGRATE_DIR;
+            return HelperUtils.ClearAppServiceDirectory(linAppMigrateIntermerdiateDirectory, destinationSite.ftpUsername, destinationSite.ftpPassword, destinationSite.webAppName);
+        }
+
     }
 }

--- a/StartUp.cs
+++ b/StartUp.cs
@@ -1,3 +1,7 @@
+using System.Diagnostics;
+using System.Text;
+using Renci.SshNet;
+using Ionic.Zip;
 namespace WordPressMigrationTool
 {
     internal static class StartUp
@@ -22,7 +26,7 @@ namespace WordPressMigrationTool
 
             SiteInfo sourceSiteInfo = new SiteInfo(args[0], args[1], args[2]);
             SiteInfo destinationSiteInfo = new SiteInfo(args[3], args[4], args[5]);
-            Console.WriteLine(new MigrationService().Migrate(sourceSiteInfo, destinationSiteInfo));
+            Console.WriteLine(new MigrationService().migrate(sourceSiteInfo, destinationSiteInfo));
         }
     }
 }

--- a/StartUp.cs
+++ b/StartUp.cs
@@ -16,7 +16,7 @@ namespace WordPressMigrationTool
             ////// see https://aka.ms/applicationconfiguration.
             ////ApplicationConfiguration.Initialize();
             ////Application.Run(new MigrationUX());
-
+            /*
             if (args.Length < 6)
             {
                 Console.WriteLine("Insufficient input data! Please provide all " +
@@ -27,7 +27,9 @@ namespace WordPressMigrationTool
             SiteInfo sourceSiteInfo = new SiteInfo(args[0], args[1], args[2]);
             SiteInfo destinationSiteInfo = new SiteInfo(args[3], args[4], args[5]);
             Console.WriteLine(new MigrationService().migrate(sourceSiteInfo, destinationSiteInfo));
-
+            */
+            SiteInfo destinationSiteInfo = new SiteInfo("b233f3cd-c75c-4aa4-b90b-d1bc66fdc5e7", "defaultwp", "defaultwp");
+            Console.WriteLine(new ImportService().importDataToDestinationSite(destinationSiteInfo, "newdatabase"));
         }
     }
 }

--- a/StartUp.cs
+++ b/StartUp.cs
@@ -16,7 +16,7 @@ namespace WordPressMigrationTool
             ////// see https://aka.ms/applicationconfiguration.
             ////ApplicationConfiguration.Initialize();
             ////Application.Run(new MigrationUX());
-            /*
+            
             if (args.Length < 6)
             {
                 Console.WriteLine("Insufficient input data! Please provide all " +
@@ -27,9 +27,6 @@ namespace WordPressMigrationTool
             SiteInfo sourceSiteInfo = new SiteInfo(args[0], args[1], args[2]);
             SiteInfo destinationSiteInfo = new SiteInfo(args[3], args[4], args[5]);
             Console.WriteLine(new MigrationService().migrate(sourceSiteInfo, destinationSiteInfo));
-            */
-            SiteInfo destinationSiteInfo = new SiteInfo("b233f3cd-c75c-4aa4-b90b-d1bc66fdc5e7", "defaultwp", "defaultwp");
-            Console.WriteLine(new ImportService().importDataToDestinationSite(destinationSiteInfo, "newdatabase"));
         }
     }
 }

--- a/StartUp.cs
+++ b/StartUp.cs
@@ -27,6 +27,7 @@ namespace WordPressMigrationTool
             SiteInfo sourceSiteInfo = new SiteInfo(args[0], args[1], args[2]);
             SiteInfo destinationSiteInfo = new SiteInfo(args[3], args[4], args[5]);
             Console.WriteLine(new MigrationService().migrate(sourceSiteInfo, destinationSiteInfo));
+
         }
     }
 }

--- a/Utilities/AzureManagementUtils.cs
+++ b/Utilities/AzureManagementUtils.cs
@@ -117,5 +117,21 @@ namespace WordPressMigrationTool.Utilities
             webSiteResource.UpdateApplicationSettings(appSettings);
             return true;
         }
+
+        public static bool removeApplicationSettingForAppService(WebSiteResource webSiteResource, string[] appSettingsToRemove)
+        {
+            Response<AppServiceConfigurationDictionary> appSettings = webSiteResource.GetApplicationSettings();
+            if (appSettings == null || appSettings.Value == null || appSettings.Value.Properties == null)
+            {
+                throw new ArgumentException("Unable to configure application settings for App Service.");
+            }
+
+            foreach (string appSettingToRemove in appSettingsToRemove)
+            {
+                appSettings.Value.Properties.Remove(appSettingToRemove);
+            }
+            webSiteResource.UpdateApplicationSettings(appSettings);
+            return true;
+        }
     }
 }

--- a/Utilities/Constants.cs
+++ b/Utilities/Constants.cs
@@ -62,7 +62,8 @@ namespace WordPressMigrationTool.Utilities
         public const string NEW_DATABASE_NAME_APP_SETTING = "MIGRATE_NEW_DATABASE_NAME";
         public const string MYSQL_DUMP_FILE_PATH_APP_SETTING = "MIGRATE_MYSQL_DUMP_PATH";
 
-        public const string DB_IMPORT_STATUS_MESSAGE = "MYSQL_DB_IMPORT_COMPLETED";
+        public const string DB_IMPORT_SUCCESS_MESSAGE = "MYSQL_DB_IMPORT_COMPLETED";
+        public const string DB_IMPORT_FAILURE_MESSAGE = "MYSQL_DB_IMPORT_FAILED";
         public const string LIN_APP_DB_STATUS_FILE_PATH = "/home/dev/migrate/mysql/mysql_import_status.txt";
 
     }

--- a/Utilities/Constants.cs
+++ b/Utilities/Constants.cs
@@ -1,16 +1,28 @@
 ﻿using System;
+using System.Reflection.Metadata;
 
 namespace WordPressMigrationTool.Utilities
 {
     public static class Constants
     {
+        public const int KUDU_ZIP_API_MAX_UPLOAD_LIMIT = 100000000;     // 100 Million Bytes
+
+        public const string WIN_WPCONTENT_ZIP_FILENAME = "wpcontent.zip";
+        public const string WIN_MYSQL_ZIP_FILENAME = "mysqldata.zip";
+
         public const string DATA_EXPORT_PATH = "%userprofile%\\AppData\\Local\\WordPressMigration\\";
-        public const string WIN_APPSERVICE_DATA_EXPORT_PATH = DATA_EXPORT_PATH + "wpcontent.zip";
-        public const string WIN_MYSQL_DATA_EXPORT_SQLFILE_PATH = DATA_EXPORT_PATH + "mysqldata.sql";
+        public const string WIN_APPSERVICE_DATA_EXPORT_PATH = DATA_EXPORT_PATH + WIN_WPCONTENT_ZIP_FILENAME;
+        public const string WIN_MYSQL_DATA_EXPORT_SQLFILE_PATH = DATA_EXPORT_PATH + WIN_MYSQL_ZIP_FILENAME;
         public const string WIN_MYSQL_DATA_EXPORT_COMPRESSED_SQLFILE_PATH = DATA_EXPORT_PATH + "mysqldata.zip";
 
         public const int MAX_WIN_APPSERVICE_RETRIES = 3;
         public const int MAX_WIN_MYSQLDATA_RETRIES = 3;
+        public const int MAX_APPDATA_UPLOAD_RETRIES = 3;
+        public const int MAX_MYSQLDATA_UPLOAD_RETRIES = 3;
+        public const int MAX_WPCONTENT_CLEAR_RETRIES = 10;
+        public const int MAX_RETRIES_COMMON = 3;
+        public const int MAX_APP_CLEAR_DIR_RETRIES = 10;
+
         public const string SUCCESS_EXPORT_MESSAGE = "Successfully exported the data from Windows WordPress!";
         public const string SUCCESS_IMPORT_MESSAGE = "Successfully imported the data to Linux WordPress!";
         public const string SUCCESS_MESSAGE = "Migration has been completed successfully!";
@@ -19,6 +31,39 @@ namespace WordPressMigrationTool.Utilities
         public const string APPSETTING_DATABASE_NAME = "DATABASE_NAME";
         public const string APPSETTING_DATABASE_USERNAME = "DATABASE_USERNAME";
         public const string APPSETTING_DATABASE_PASSWORD = "DATABASE_PASSWORD";
+
+
+        // below value should not end with '/'
+        public const string LIN_APP_SVC_WPCONTENT_DIR = "/home/site/wwwroot/wp-content";
+        public const string LIN_MYSQL_DUMP_UPLOAD_PATH_FOR_KUDU_API = "dev/migrate/mysql";
+
+        public const string WPCONTENT_SPLIT_ZIP_FILES_DIR = DATA_EXPORT_PATH + "wpContentSplitDir\\";
+        public const string WPCONTENT_SPLIT_ZIP_FILE_NAME_PREFIX = "WpContentSplit";
+        public const string WPCONTENT_SPLIT_ZIP_FILE_NAME = WPCONTENT_SPLIT_ZIP_FILE_NAME_PREFIX + ".zip";
+        public const string WPCONTENT_SPLIT_ZIP_FILE_PATH = WPCONTENT_SPLIT_ZIP_FILES_DIR + WPCONTENT_SPLIT_ZIP_FILE_NAME;
+        public const string WPCONTENT_SPLIT_ZIP_NESTED_DIR = DATA_EXPORT_PATH + "ZippedWpContentSplitFiles\\";
+
+        public const string LIN_APP_SVC_MIGRATE_DIR = "/home/dev/migrate/";
+        public const string WPCONTENT_TEMP_DIR = LIN_APP_SVC_MIGRATE_DIR + "wpcontentSplit/";
+        public const string WPCONTENT_TEMP_DIR_KUDU_API = "dev/migrate/wpcontentSplit/";
+        public const string WPCONTENT_TEMP_ZIP_PATH = LIN_APP_SVC_MIGRATE_DIR + "wp-content-temp.zip";
+        public const string WPCONTENT_CREATE_TEMP_DIR_COMMAND = "mkdir -p " + WPCONTENT_TEMP_DIR;
+        public const string WPCONTENT_MERGE_SPLLIT_FILES_COMAMND = "zip -FF " + WPCONTENT_TEMP_DIR + WPCONTENT_SPLIT_ZIP_FILE_NAME_PREFIX + ".zip --out " + WPCONTENT_TEMP_ZIP_PATH;
+        public const string UNZIP_MERGED_WPCONTENT_COMMAND = "yes | unzip " + WPCONTENT_TEMP_ZIP_PATH + " -d " + LIN_APP_SVC_WPCONTENT_DIR;
+
+        public const string MYSQL_TEMP_DIR = LIN_APP_SVC_MIGRATE_DIR + "mysql/";
+
+        public const string MYSQL_CREATE_TEMP_DIR_COMMAND = "mkdir -p " + MYSQL_TEMP_DIR;
+        public const string CLEAR_APP_SERVICE_DIR_COMMAND = "rm -rf {0}";
+        public const string LIST_DIR_COMMAND = "ls {0}";
+        public const string LIN_APP_MAKE_DIR_COMMAND = "mkdir -p {0}";
+
+        public const string START_MIGRATION_APP_SETTING = "MIGRATION_IN_PROGRESS";
+        public const string NEW_DATABASE_NAME_APP_SETTING = "MIGRATE_NEW_DATABASE_NAME";
+        public const string MYSQL_DUMP_FILE_PATH_APP_SETTING = "MIGRATE_MYSQL_DUMP_PATH";
+
+        public const string DB_IMPORT_STATUS_MESSAGE = "MYSQL_DB_IMPORT_COMPLETED";
+        public const string LIN_APP_DB_STATUS_FILE_PATH = "/home/dev/migrate/mysql/mysql_import_status.txt";
 
     }
 }

--- a/Utilities/Constants.cs
+++ b/Utilities/Constants.cs
@@ -43,15 +43,15 @@ namespace WordPressMigrationTool.Utilities
         public const string WPCONTENT_SPLIT_ZIP_FILE_PATH = WPCONTENT_SPLIT_ZIP_FILES_DIR + WPCONTENT_SPLIT_ZIP_FILE_NAME;
         public const string WPCONTENT_SPLIT_ZIP_NESTED_DIR = DATA_EXPORT_PATH + "ZippedWpContentSplitFiles\\";
 
+        public const string MYSQL_TEMP_DIR = LIN_APP_SVC_MIGRATE_DIR + "mysql/";
+
         public const string LIN_APP_SVC_MIGRATE_DIR = "/home/dev/migrate/";
-        public const string WPCONTENT_TEMP_DIR = LIN_APP_SVC_MIGRATE_DIR + "wpcontentSplit/";
-        public const string WPCONTENT_TEMP_DIR_KUDU_API = "dev/migrate/wpcontentSplit/";
+        public const string WPCONTENT_TEMP_DIR = LIN_APP_SVC_MIGRATE_DIR + "wpcontentsplit/";
+        public const string WPCONTENT_TEMP_DIR_KUDU_API = "dev/migrate/wpcontentsplit/";
         public const string WPCONTENT_TEMP_ZIP_PATH = LIN_APP_SVC_MIGRATE_DIR + "wp-content-temp.zip";
         public const string WPCONTENT_CREATE_TEMP_DIR_COMMAND = "mkdir -p " + WPCONTENT_TEMP_DIR;
         public const string WPCONTENT_MERGE_SPLLIT_FILES_COMAMND = "zip -FF " + WPCONTENT_TEMP_DIR + WPCONTENT_SPLIT_ZIP_FILE_NAME_PREFIX + ".zip --out " + WPCONTENT_TEMP_ZIP_PATH;
         public const string UNZIP_MERGED_WPCONTENT_COMMAND = "yes | unzip " + WPCONTENT_TEMP_ZIP_PATH + " -d " + LIN_APP_SVC_WPCONTENT_DIR;
-
-        public const string MYSQL_TEMP_DIR = LIN_APP_SVC_MIGRATE_DIR + "mysql/";
 
         public const string MYSQL_CREATE_TEMP_DIR_COMMAND = "mkdir -p " + MYSQL_TEMP_DIR;
         public const string CLEAR_APP_SERVICE_DIR_COMMAND = "rm -rf {0}";

--- a/Utilities/Constants.cs
+++ b/Utilities/Constants.cs
@@ -32,10 +32,13 @@ namespace WordPressMigrationTool.Utilities
         public const string APPSETTING_DATABASE_USERNAME = "DATABASE_USERNAME";
         public const string APPSETTING_DATABASE_PASSWORD = "DATABASE_PASSWORD";
 
+        public const string LIN_APP_WP_CONFIG_PATH = "/home/site/wwwroot/wp-config.php";
+        public const string LIN_APP_VERSIONPHP_FILE_PATH = "/home/site/wwwroot/wp-includes/version.php";
+        public const string LIN_APP_WP_DEPLOYMENT_STATUS_FILE_PATH = "/home/wp-locks/wp_deployment_status.txt";
         // below value should not end with '/'
         public const string LIN_APP_SVC_WPCONTENT_DIR = "/home/site/wwwroot/wp-content";
         public const string LIN_APP_SVC_ROOT_DIR = "/home/site/wwwroot/";
-        public const string LIN_APP_WORDPRESS_SRC_CODE_DIR = "/usr/src/wordpress/";
+        public const string LIN_APP_WORDPRESS_SRC_CODE_DIR = "/usr/src/wordpress/wordpress-azure/";
         public const string LIN_MYSQL_DUMP_UPLOAD_PATH_FOR_KUDU_API = "dev/migrate/mysql";
 
         public const string WPCONTENT_SPLIT_ZIP_FILES_DIR = DATA_EXPORT_PATH + "wpContentSplitDir\\";
@@ -64,6 +67,7 @@ namespace WordPressMigrationTool.Utilities
         public const string MYSQL_DUMP_FILE_PATH_APP_SETTING = "MIGRATE_MYSQL_DUMP_PATH";
         public const string LIN_APP_PREVENT_WORDPRESS_INSTALL_APP_SETTING = "SKIP_WP_INSTALLATION";
 
+        public const string FIRST_TIME_SETUP_COMPLETETED_MESSAGE = "FIRST_TIME_SETUP_COMPLETED";
         public const string DB_IMPORT_SUCCESS_MESSAGE = "MYSQL_DB_IMPORT_COMPLETED";
         public const string DB_IMPORT_FAILURE_MESSAGE = "MYSQL_DB_IMPORT_FAILED";
         public const string LIN_APP_DB_STATUS_FILE_PATH = "/home/dev/migrate/mysql/mysql_import_status.txt";

--- a/Utilities/Constants.cs
+++ b/Utilities/Constants.cs
@@ -32,9 +32,10 @@ namespace WordPressMigrationTool.Utilities
         public const string APPSETTING_DATABASE_USERNAME = "DATABASE_USERNAME";
         public const string APPSETTING_DATABASE_PASSWORD = "DATABASE_PASSWORD";
 
-
         // below value should not end with '/'
         public const string LIN_APP_SVC_WPCONTENT_DIR = "/home/site/wwwroot/wp-content";
+        public const string LIN_APP_SVC_ROOT_DIR = "/home/site/wwwroot/";
+        public const string LIN_APP_WORDPRESS_SRC_CODE_DIR = "/usr/src/wordpress/";
         public const string LIN_MYSQL_DUMP_UPLOAD_PATH_FOR_KUDU_API = "dev/migrate/mysql";
 
         public const string WPCONTENT_SPLIT_ZIP_FILES_DIR = DATA_EXPORT_PATH + "wpContentSplitDir\\";
@@ -61,6 +62,7 @@ namespace WordPressMigrationTool.Utilities
         public const string START_MIGRATION_APP_SETTING = "MIGRATION_IN_PROGRESS";
         public const string NEW_DATABASE_NAME_APP_SETTING = "MIGRATE_NEW_DATABASE_NAME";
         public const string MYSQL_DUMP_FILE_PATH_APP_SETTING = "MIGRATE_MYSQL_DUMP_PATH";
+        public const string LIN_APP_PREVENT_WORDPRESS_INSTALL_APP_SETTING = "SKIP_WP_INSTALLATION";
 
         public const string DB_IMPORT_SUCCESS_MESSAGE = "MYSQL_DB_IMPORT_COMPLETED";
         public const string DB_IMPORT_FAILURE_MESSAGE = "MYSQL_DB_IMPORT_FAILED";

--- a/Utilities/HelperUtils.cs
+++ b/Utilities/HelperUtils.cs
@@ -1,5 +1,17 @@
 ﻿using System;
 using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Text;
+using Newtonsoft.Json;
+using Org.BouncyCastle.Asn1.Ocsp;
+using System.Net;
+using System.Net.Http.Headers;
+using Ionic.Zip;
+using System.Reflection.Metadata;
+using Org.BouncyCastle.Ocsp;
+using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace WordPressMigrationTool.Utilities
 {
@@ -11,6 +23,24 @@ namespace WordPressMigrationTool.Utilities
             if (!string.IsNullOrWhiteSpace(appServiceName))
             {
                 return "https://" + appServiceName + ".scm.azurewebsites.net/api/zip/site/wwwroot/wp-content/";
+            }
+            return null;
+        }
+
+         public static string getKuduUrlForZipUpload(string appServiceName, string uploadPath)
+        {
+            if (!string.IsNullOrWhiteSpace(appServiceName))
+            {
+                return "https://" + appServiceName + ".scm.azurewebsites.net/api/zip/" + uploadPath;
+            }
+            return null;
+        }
+
+        public static string getKuduUrlForCommandExec(string appServiceName)
+        {
+            if (!string.IsNullOrWhiteSpace(appServiceName))
+            {
+                return "https://" + appServiceName + ".scm.azurewebsites.net/api/command";
             }
             return null;
         }
@@ -66,6 +96,126 @@ namespace WordPressMigrationTool.Utilities
             {
                 File.Delete(filePath);
             }
+        }
+
+        public static KuduCommandApiResult executeKuduCommandApi(string inputCommand, string ftpUsername, string ftpPassword, string appServiceName, int maxRetryCount = 3) {
+            if (maxRetryCount <=0 )
+            {
+                return new KuduCommandApiResult(Status.Failed);
+            }
+            string command = String.Format("bash -c \" {0} \"", inputCommand);
+            var appServiceKuduCommandURL = getKuduUrlForCommandExec(appServiceName);
+            int trycount=1;
+            while(trycount <= maxRetryCount)
+            {
+                using (var client = new HttpClient())
+                {
+                    var jsonString = JsonConvert.SerializeObject(new { command = command, dir = "" });
+                    HttpContent httpContent = new StringContent(jsonString);
+                    httpContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue ("application/json");
+
+                    // Set Basic auth
+                    var byteArray = Encoding.ASCII.GetBytes(ftpUsername + ":" + ftpPassword);
+                    client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
+
+                    HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Post, appServiceKuduCommandURL);
+                    requestMessage.Content = httpContent;
+
+                    HttpResponseMessage response = client.Send(requestMessage);
+
+                    // Convert response to Json
+                    var responseStream = response.Content.ReadAsStream();
+                    var myStreamReader = new StreamReader(responseStream, Encoding.UTF8);
+                    var responseJSON = myStreamReader.ReadToEnd();
+                    var responseData = JsonConvert.DeserializeObject<KuduCommandApiResponse>(responseJSON);
+
+                    if (responseData != null && response.IsSuccessStatusCode)
+                    {
+                        return new KuduCommandApiResult(Status.Completed, responseData.Output, responseData.Error, responseData.ExitCode);
+                    }
+
+                    trycount++;
+                    if (trycount > Constants.MAX_APPDATA_UPLOAD_RETRIES)
+                    {
+                        return new KuduCommandApiResult(Status.Failed);
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+            }
+            return new KuduCommandApiResult(Status.Failed);
+        }
+    
+        public static bool ClearAppServiceDirectory (string targetFolder, string ftpUsername, string ftpPassword, string appServiceName )
+        {
+            int maxRetryCount = Constants.MAX_APP_CLEAR_DIR_RETRIES;
+            if (maxRetryCount <=0 )
+            {
+                return false;
+            }
+
+            string listTargetDirCommand = String.Format(Constants.LIST_DIR_COMMAND, targetFolder);
+            string clearTargetDirCommand = String.Format(Constants.CLEAR_APP_SERVICE_DIR_COMMAND, targetFolder);
+            string createTargetDirCommand = String.Format(Constants.LIN_APP_MAKE_DIR_COMMAND, targetFolder);
+
+            int trycount = 1;
+            while(trycount <= maxRetryCount)
+            {
+                KuduCommandApiResult checkTargetDirEmptyResult =  executeKuduCommandApi(listTargetDirCommand, ftpUsername, ftpPassword, appServiceName, Constants.MAX_APP_CLEAR_DIR_RETRIES );
+                if (checkTargetDirEmptyResult.exitCode == 0 && String.IsNullOrEmpty(checkTargetDirEmptyResult.output))
+                {
+                    return true;
+                }
+
+                KuduCommandApiResult clearTargeDirResult = executeKuduCommandApi(clearTargetDirCommand, ftpUsername, ftpPassword, appServiceName, Constants.MAX_APP_CLEAR_DIR_RETRIES );
+
+                KuduCommandApiResult makeTargetDir = executeKuduCommandApi(createTargetDirCommand, ftpUsername, ftpPassword, appServiceName, Constants.MAX_RETRIES_COMMON);
+                trycount++;
+            }
+            return false;
+        }
+
+        public static bool LinAppServiceUploadZip(string zipFilePath, string kuduUploadUrl, string ftpUsername, string ftpPassword)
+        {
+            int retryCount = 1;
+            while (retryCount <= Constants.MAX_APPDATA_UPLOAD_RETRIES)
+            {
+                using (var client = new HttpClient())
+                {
+                    client.DefaultRequestHeaders.Accept.Clear();
+                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/zip"));
+
+                    ByteArrayContent content = new ByteArrayContent(System.IO.File.ReadAllBytes(zipFilePath));
+                    content.Headers.ContentType = MediaTypeHeaderValue.Parse("application/octet-stream");
+
+                    var byteArray = Encoding.ASCII.GetBytes(ftpUsername + ":" + ftpPassword);
+                    client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Basic", Convert.ToBase64String(byteArray));
+
+                    HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Put, kuduUploadUrl);
+                    requestMessage.Content = content;
+
+                    HttpResponseMessage response = client.Send(requestMessage);
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        break;
+                    }
+
+                    retryCount++;
+                    if (retryCount > Constants.MAX_APPDATA_UPLOAD_RETRIES)
+                    {
+                        return false;
+                    }
+                    else
+                    {
+                        continue;
+                    }
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/Views/MigrationUX.cs
+++ b/Views/MigrationUX.cs
@@ -36,10 +36,10 @@ namespace WordPressMigrationTool
 
             SiteInfo sourceSiteInfo = new SiteInfo(winSubscriptionId, winResourceGroupName, winAppServiceName);
             SiteInfo destinationSiteInfo = new SiteInfo(linuxSubscriptionId, linuxResourceGroupName, linuxAppServiceName);
-
+            /*
             try
             {
-                Result result = new MigrationService().Migrate(sourceSiteInfo, destinationSiteInfo);
+                Result result =  new MigrationService().migrate(sourceSiteInfo, destinationSiteInfo);
                 DialogResult errorDialogRes = MessageBox.Show(result.message, "Error Message", MessageBoxButtons.OKCancel);
                 if (errorDialogRes == DialogResult.OK)
                 {
@@ -53,7 +53,7 @@ namespace WordPressMigrationTool
                 {
                     return;
                 }
-            }
+            }*/
         }
     }
 }

--- a/Views/MigrationUX.cs
+++ b/Views/MigrationUX.cs
@@ -36,7 +36,7 @@ namespace WordPressMigrationTool
 
             SiteInfo sourceSiteInfo = new SiteInfo(winSubscriptionId, winResourceGroupName, winAppServiceName);
             SiteInfo destinationSiteInfo = new SiteInfo(linuxSubscriptionId, linuxResourceGroupName, linuxAppServiceName);
-            /*
+            
             try
             {
                 Result result =  new MigrationService().migrate(sourceSiteInfo, destinationSiteInfo);
@@ -53,7 +53,7 @@ namespace WordPressMigrationTool
                 {
                     return;
                 }
-            }*/
+            }
         }
     }
 }

--- a/WordPressMigrationTool.csproj
+++ b/WordPressMigrationTool.csproj
@@ -11,8 +11,11 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.7.0" />
     <PackageReference Include="Azure.ResourceManager.AppService" Version="1.0.0" />
+    <PackageReference Include="DotNetZip" Version="1.16.0" />
     <PackageReference Include="MySql.Data" Version="8.0.31" />
     <PackageReference Include="MySqlBackup.NET" Version="2.3.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Renci.SshNet.Async" Version="1.4.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
WP-Content Zip file is split locally and uploaded one-by-one to destination site.
Once uploaded, split zip files are merged in app service and extracted to /home/site/wwwroot/wp-content directory.
Split zip file size is 100 Million bytes.

MySQL file is uploaded to app service. App Settings are added to destination site which trigger mysql DB import. Migration tool keeps polling for DB import completion.

ImageBulder PR for mysql DB import trigger: https://github.com/Azure-App-Service/ImageBuilder/pull/357